### PR TITLE
Fix/sp 4207 cancel pending policy checks on workflow failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-03-30
+### Fixed
+- Fixed policy check runs remaining in "queued" status when the workflow fails before policy execution
+
 ## [1.6.0] - 2026-03-05
 ### Changed
 - Replaced `vercel/ncc` by `esbuild` to support ESM modules
@@ -190,3 +194,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.4.0]: https://github.com/scanoss/gha-code-scan/compare/v1.3.1...v1.4.0
 [1.5.0]: https://github.com/scanoss/gha-code-scan/compare/v1.4.0...v1.5.0
 [1.6.0]: https://github.com/scanoss/gha-code-scan/compare/v1.5.0...v1.6.0
+[1.6.1]: https://github.com/scanoss/gha-code-scan/compare/v1.6.0...v1.6.1

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,4 +1,4 @@
-/*! scanoss-code-scan-action v1.6.0 | MIT */
+/*! scanoss-code-scan-action v1.6.1 | MIT */
 "use strict";
 var __create = Object.create;
 var __defProp = Object.defineProperty;
@@ -136512,13 +136512,14 @@ async function createSnippetAnnotations(resultsPath) {
 
 // src/main.ts
 async function run() {
-  const policies = policyManager.getPolicies();
+  let policies = [];
   try {
     if (API_KEY) core21.setSecret(API_KEY);
     if (GITHUB_TOKEN) core21.setSecret(GITHUB_TOKEN);
     core21.debug(`SCANOSS Scan Action started...`);
     core21.debug(`Creating policies`);
     const firstRunId = await getFirstRunId();
+    policies = policyManager.getPolicies();
     for (const policy of policies) {
       await policy.start(firstRunId);
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -24510,10 +24510,10 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
       (0, command_1.issueCommand)("error", (0, utils_1.toCommandProperties)(properties), message instanceof Error ? message.toString() : message);
     }
     exports2.error = error9;
-    function warning14(message, properties = {}) {
+    function warning15(message, properties = {}) {
       (0, command_1.issueCommand)("warning", (0, utils_1.toCommandProperties)(properties), message instanceof Error ? message.toString() : message);
     }
-    exports2.warning = warning14;
+    exports2.warning = warning15;
     function notice2(message, properties = {}) {
       (0, command_1.issueCommand)("notice", (0, utils_1.toCommandProperties)(properties), message instanceof Error ? message.toString() : message);
     }
@@ -134085,6 +134085,15 @@ var PolicyCheck = class {
     this._status = "RUNNING" /* RUNNING */;
   }
   /**
+   * Cancels the policy check when the workflow fails before policy execution.
+   * Only acts on check runs that were started but not yet finished.
+   */
+  async cancel(summary3) {
+    if (this._status === "FINISHED" /* FINISHED */ || this._status === "UNINITIALIZED" /* UNINITIALIZED */) return;
+    this._conclusion = "cancelled" /* Cancelled */;
+    await this.finish(summary3);
+  }
+  /**
    * Marks the policy check as successful.
    */
   async success(summary3, text) {
@@ -136503,13 +136512,13 @@ async function createSnippetAnnotations(resultsPath) {
 
 // src/main.ts
 async function run() {
+  const policies = policyManager.getPolicies();
   try {
     if (API_KEY) core21.setSecret(API_KEY);
     if (GITHUB_TOKEN) core21.setSecret(GITHUB_TOKEN);
     core21.debug(`SCANOSS Scan Action started...`);
     core21.debug(`Creating policies`);
     const firstRunId = await getFirstRunId();
-    const policies = policyManager.getPolicies();
     for (const policy of policies) {
       await policy.start(firstRunId);
     }
@@ -136541,6 +136550,13 @@ async function run() {
     core21.setOutput(RESULT_FILEPATH, OUTPUT_FILEPATH);
     core21.setOutput(STDOUT_SCAN_COMMAND, stdout);
   } catch (error9) {
+    for (const policy of policies) {
+      try {
+        await policy.cancel(error9 instanceof Error ? error9.message : "Workflow failed");
+      } catch (e) {
+        core21.warning(`Failed to cancel policy check "${policy.name}": ${e instanceof Error ? e.message : e}`);
+      }
+    }
     if (error9 instanceof Error) core21.setFailed(error9.message);
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scanoss-code-scan-action",
   "description": "SCANOSS Code Scan Action",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": "SCANOSS",
   "private": true,
   "homepage": "https://github.com/scanoss/code-scan-action/",

--- a/sbom.json
+++ b/sbom.json
@@ -1,7 +1,0 @@
-{
-    "components": [
-        {
-            "purl": "pkg:github/scanoss/code-scan-action"
-        }
-    ]
-}

--- a/scanoss.json
+++ b/scanoss.json
@@ -1,0 +1,12 @@
+{
+  "bom": {
+    "include": [
+      {
+        "purl": "pkg:github/scanoss/gha-code-scan"
+      },
+      {
+        "purl": "pkg:github/plinioh/setup-binary-action"
+      }
+    ]
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ import * as inputs from './app.input';
 import * as outputs from './app.output';
 import { scanService, uploadResults } from './services/scan.service';
 import { policyManager } from './policies/policy.manager';
+import { PolicyCheck } from './policies/policy-check';
 import { DepTrackPolicyCheck } from './policies/dep-track-policy-check';
 import { dependencyTrackService } from './services/dependency-track.service';
 import { dependencyTrackStatusService } from './services/dependency-track-status.service';
@@ -39,6 +40,7 @@ import { createSnippetAnnotations } from './utils/snippet-annotations.utils';
  * @returns {Promise<void>} Resolves when the action is complete.
  */
 export async function run(): Promise<void> {
+  let policies: PolicyCheck[] = [];
   try {
     // Mask sensitive inputs to prevent accidental leakage in logs
     if (inputs.API_KEY) core.setSecret(inputs.API_KEY);
@@ -49,9 +51,7 @@ export async function run(): Promise<void> {
     // create policies
     core.debug(`Creating policies`);
     const firstRunId = await getFirstRunId();
-
-    //Read declared policies on input parameter 'policies' and create an instance for each one.
-    const policies = policyManager.getPolicies();
+    policies = policyManager.getPolicies();
     for (const policy of policies) {
       await policy.start(firstRunId);
     }
@@ -99,6 +99,14 @@ export async function run(): Promise<void> {
     core.setOutput(outputs.RESULT_FILEPATH, inputs.OUTPUT_FILEPATH);
     core.setOutput(outputs.STDOUT_SCAN_COMMAND, stdout);
   } catch (error) {
+    // Cancel any pending policy check runs so they don't remain in "queued" status
+    for (const policy of policies) {
+      try {
+        await policy.cancel(error instanceof Error ? error.message : 'Workflow failed');
+      } catch (e) {
+        core.warning(`Failed to cancel policy check "${policy.name}": ${e instanceof Error ? e.message : e}`);
+      }
+    }
     // fail the workflow run if an error occurs
     if (error instanceof Error) core.setFailed(error.message);
   }

--- a/src/policies/policy-check.ts
+++ b/src/policies/policy-check.ts
@@ -162,6 +162,16 @@ export abstract class PolicyCheck {
   }
 
   /**
+   * Cancels the policy check when the workflow fails before policy execution.
+   * Only acts on check runs that were started but not yet finished.
+   */
+  async cancel(summary: string): Promise<void> {
+    if (this._status === STATUS.FINISHED || this._status === STATUS.UNINITIALIZED) return;
+    this._conclusion = CONCLUSION.Cancelled;
+    await this.finish(summary);
+  }
+
+  /**
    * Marks the policy check as successful.
    */
   protected async success(summary: string, text?: string): Promise<void> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Policy check runs no longer remain stuck in "queued" status when workflows fail before policy execution begins.

* **Documentation**
  * Added changelog entry for v1.6.1 (2026-03-30) with release link.

* **Chores**
  * Bumped package version to 1.6.1.
  * Added new scanoss.json configuration and removed sbom.json.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->